### PR TITLE
Rough support of multiple types in dynamic import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,9 @@ import('./my/module/MyClass')
   .then(console.log)
 ```
 
-Genes expects a single-argument function declaration expression (`EFunction`) as the sole argument of `dynamicImport` and it will do 2 things:
+Genes expects a function declaration expression (`EFunction`) as the sole argument of `dynamicImport` and it will do 2 things:
 
-1. Get the argument name (e.g. "MyClass") and resolve it as a type in the current context, taking Haxe `import` statements into account. This is for preparing the relative path of the target file (e.g. `'../../MyClass.js'`).
+1. For each arguments, take the argument name (e.g. "MyClass") and resolve it as a type in the current context, taking Haxe `import` statements into account. This is for preparing the relative path of the target files (e.g. `'../../MyClass.js'`).
 2. Type the function body in the current context, ignoring the fact that it is a function body. Thus in the example the scope of `MyClass` is not the function argument but in current context i.e. the actual type `class MyClass {...}`. The return type is then applied as the type parameter of `js.lib.Promise`. This is for hinting the return type of the `dynamicImport(...)` call so that the compiler can do its typing job properly.
 
 ## Alternatives

--- a/src/genes/Genes.hx
+++ b/src/genes/Genes.hx
@@ -38,7 +38,8 @@ class Genes {
         final setups = [];
         final imports = [];
 
-        for (i => arg in args) {
+        for (i in 0...args.length) {
+          final arg = args[i];
           final name = arg.name;
           final type = Context.getType(name);
           final current = Context.getLocalClass().get().module;

--- a/src/genes/Genes.hx
+++ b/src/genes/Genes.hx
@@ -26,7 +26,7 @@ class Genes {
         final current = Context.getLocalClass().get().module;
         final ret = Context.typeExpr(body).t.toComplexType();
 
-        final modules:Array<ImportedModule> = [];
+        final modules: Array<ImportedModule> = [];
 
         for (arg in args) {
           final name = arg.name;
@@ -61,14 +61,8 @@ class Genes {
                 macro js.Syntax.code($v{'var ${sub.name} = module.${sub.name}'})
             ];
 
-            // generate ignore/ignoreMultiple depending on the number of types
-            final ignore = switch module.types {
-              case [sub]:
-                body -> macro genes.Genes.ignore($v{sub.name}, $body);
-              case types:
-                final list = [for (sub in types) macro $v{sub.name}];
-                body -> macro genes.Genes.ignoreMultiple($a{list}, $body);
-            }
+            final list = [for (sub in module.types) macro $v{sub.name}];
+            final ignore = body -> macro genes.Genes.ignore($a{list}, $body);
 
             final handler = ignore(macro function(module) {
               @:mergeBlock $b{setup};
@@ -90,7 +84,7 @@ class Genes {
 
             final imports = macro $a{modules.map(module -> module.importExpr)};
             macro js.lib.Promise.all($imports)
-              .then(genes.Genes.ignoreMultiple($a{ignores}, function(modules) {
+              .then(genes.Genes.ignore($a{ignores}, function(modules) {
                 @:mergeBlock $b{setup};
                 $body;
               }));
@@ -103,9 +97,6 @@ class Genes {
     }
   }
 
-  public static function ignore<T>(name: String, res: T)
-    return res;
-
-  public static function ignoreMultiple<T>(name: Array<String>, res: T)
+  public static function ignore<T>(names: Array<String>, res: T)
     return res;
 }

--- a/src/genes/Genes.hx
+++ b/src/genes/Genes.hx
@@ -12,6 +12,8 @@ using haxe.macro.TypeTools;
 class Genes {
   macro public static function dynamicImport<T, R>(expr: ExprOf<T->
     R>): ExprOf<js.lib.Promise<R>> {
+    final pos = Context.currentPos();
+
     return switch expr.expr {
       case EFunction(_, {args: [arg], expr: body}):
         final name = arg.name;
@@ -21,18 +23,48 @@ class Genes {
         final path = PathUtil.relative(current.replace('.', '/'),
           to.replace('.', '/'));
         final ret = Context.typeExpr(body).t.toComplexType();
-        final setup = {expr: EConst(CString('var $name = module.$name')),
-          pos: Context.currentPos()}
+        final setup = macro @:pos(pos) js.Syntax.code($v{'var $name = module.$name'});
         macro(js.Syntax.code('import({0})', $v{path})
           .then(genes.Genes.ignore($v{name}, function(module) {
-            js.Syntax.code($setup);
+            $setup;
             $body;
           })) : js.lib.Promise<$ret>);
+
+      case EFunction(_, {args: args, expr: body}):
+        // TODO: should be more intelligent not to generate duplicated `import` calls if referring to the same js modules (e.g. when using Haxe module sub-types)
+        final ret = Context.typeExpr(body).t.toComplexType();
+
+        final names = [];
+        final setups = [];
+        final imports = [];
+
+        for (i => arg in args) {
+          final name = arg.name;
+          final type = Context.getType(name);
+          final current = Context.getLocalClass().get().module;
+          final to = TypeUtil.moduleTypeName(TypeUtil.typeToModuleType(type));
+          final path = PathUtil.relative(current.replace('.', '/'),
+            to.replace('.', '/'));
+          names.push(macro @:pos(pos) $v{name});
+          imports.push(macro @:pos(pos) js.Syntax.code('import({0})',
+            $v{path}));
+          setups.push(macro @:pos(pos) js.Syntax.code($v{'var $name = modules[$i].$name'}));
+        }
+        final importExprs = macro @:pos(pos) $a{imports};
+        macro(js.lib.Promise.all($importExprs)
+          .then(genes.Genes.ignoreMultiple($a{names}, function(modules) {
+            @:mergeBlock $b{setups};
+            $body;
+          })) : js.lib.Promise<$ret>);
+
       default:
         Context.error('Cannot import', expr.pos);
     }
   }
 
   public static function ignore<T>(name: String, res: T)
+    return res;
+
+  public static function ignoreMultiple<T>(name: Array<String>, res: T)
     return res;
 }

--- a/src/genes/es/ExprEmitter.hx
+++ b/src/genes/es/ExprEmitter.hx
@@ -212,7 +212,7 @@ class ExprEmitter extends Emitter {
       case TCall({
         expr: TField(_,
           FStatic(_.get() => {module: 'genes.Genes'},
-            _.get() => {name: 'ignore' | 'ignoreMultiple'}))
+            _.get() => {name: 'ignore'}))
       }, [_, body]):
         emitExpr(body);
       case TCall(e, params):
@@ -514,7 +514,7 @@ class ExprEmitter extends Emitter {
       case TCall({
         expr: TField(_,
           FStatic(_.get() => {module: 'genes.Genes'},
-            _.get() => {name: 'ignore' | 'ignoreMultiple'}))
+            _.get() => {name: 'ignore'}))
       }, [_, body]):
         emitValue(body);
       case TCall(e, params):

--- a/src/genes/es/ExprEmitter.hx
+++ b/src/genes/es/ExprEmitter.hx
@@ -209,6 +209,12 @@ class ExprEmitter extends Emitter {
           FStatic(_.get() => {module: 'js.Syntax'}, _.get() => {name: 'code'}))
       }, _) | TCall({expr: TIdent('__js__')}, _):
         write(ctx.expr(e));
+      case TCall({
+        expr: TField(_,
+          FStatic(_.get() => {module: 'genes.Genes'},
+            _.get() => {name: 'ignore' | 'ignoreMultiple'}))
+      }, [_, body]):
+        emitExpr(body);
       case TCall(e, params):
         emitCall(e, params, false);
       case TArrayDecl(el):
@@ -505,6 +511,12 @@ class ExprEmitter extends Emitter {
           FStatic(_.get() => {module: 'js.Syntax'}, _.get() => {name: 'code'}))
       }, _) | TCall({expr: TIdent('__js__')}, _):
         write(ctx.value(e));
+      case TCall({
+        expr: TField(_,
+          FStatic(_.get() => {module: 'genes.Genes'},
+            _.get() => {name: 'ignore' | 'ignoreMultiple'}))
+      }, [_, body]):
+        emitValue(body);
       case TCall(e, params):
         emitCall(e, params, true);
       case TReturn(_) | TBreak | TContinue:

--- a/src/genes/util/TypeUtil.hx
+++ b/src/genes/util/TypeUtil.hx
@@ -54,7 +54,9 @@ class TypeUtil {
     return switch e.expr {
       case TField(x, f) if (fieldName(f) == "iterator"):
         switch Context.followWithAbstracts(x.t) {
-          case TInst(_.get() => {name: 'Array'}, _) | TInst(_.get() => {kind: KTypeParameter(_)}, _) | TAnonymous(_) | TDynamic(_) | TMono(_):
+          case TInst(_.get() => {name: 'Array'}, _) |
+            TInst(_.get() => {kind: KTypeParameter(_)}, _) | TAnonymous(_) |
+            TDynamic(_) | TMono(_):
             true;
           case _:
             false;
@@ -95,7 +97,9 @@ class TypeUtil {
       case null: [];
       case {
         expr: TCall(call = {
-          expr: TField(_, FStatic(_.get() => {module: 'genes.Genes'}, _.get() => {name: 'ignore'}))
+          expr: TField(_,
+            FStatic(_.get() => {module: 'genes.Genes'},
+              _.get() => {name: 'ignore'}))
         }, [{expr: TConst(TString(name))}, func])
       }:
         typesInExpr(call).concat(typesInExpr(func).filter(type -> {
@@ -109,7 +113,7 @@ class TypeUtil {
         expr: TCall(call = {
           expr: TField(_,
             FStatic(_.get() => {module: 'genes.Genes'},
-              _.get() => {name: 'ignoreMultiple'}))
+              _.get() => {name: 'ignore'}))
         }, [{expr: TArrayDecl(texprs)}, func])
       }:
         final names = [

--- a/src/genes/util/TypeUtil.hx
+++ b/src/genes/util/TypeUtil.hx
@@ -100,20 +100,6 @@ class TypeUtil {
           expr: TField(_,
             FStatic(_.get() => {module: 'genes.Genes'},
               _.get() => {name: 'ignore'}))
-        }, [{expr: TConst(TString(name))}, func])
-      }:
-        typesInExpr(call).concat(typesInExpr(func).filter(type -> {
-          return switch type {
-            case TClassDecl(_.get() => {name: typeName}):
-              typeName != name;
-            default: true;
-          }
-        }));
-      case {
-        expr: TCall(call = {
-          expr: TField(_,
-            FStatic(_.get() => {module: 'genes.Genes'},
-              _.get() => {name: 'ignore'}))
         }, [{expr: TArrayDecl(texprs)}, func])
       }:
         final names = [

--- a/src/genes/util/TypeUtil.hx
+++ b/src/genes/util/TypeUtil.hx
@@ -105,6 +105,29 @@ class TypeUtil {
             default: true;
           }
         }));
+      case {
+        expr: TCall(call = {
+          expr: TField(_,
+            FStatic(_.get() => {module: 'genes.Genes'},
+              _.get() => {name: 'ignoreMultiple'}))
+        }, [{expr: TArrayDecl(texprs)}, func])
+      }:
+        final names = [
+          for (texpr in texprs)
+            switch texpr {
+              case {expr: TConst(TString(name))}:
+                name;
+              case _:
+                continue; // TODO: should error
+            }
+        ];
+        typesInExpr(call).concat(typesInExpr(func).filter(type -> {
+          return switch type {
+            case TClassDecl(_.get() => {name: typeName}):
+              !names.contains(typeName);
+            default: true;
+          }
+        }));
       case {expr: TTypeExpr(t)}:
         [t];
       case {expr: TNew(c, _, el)}:

--- a/src/genes/util/TypeUtil.hx
+++ b/src/genes/util/TypeUtil.hx
@@ -124,7 +124,7 @@ class TypeUtil {
         typesInExpr(call).concat(typesInExpr(func).filter(type -> {
           return switch type {
             case TClassDecl(_.get() => {name: typeName}):
-              !names.contains(typeName);
+              names.indexOf(typeName) < 0;
             default: true;
           }
         }));

--- a/tests/ExternalClass2.hx
+++ b/tests/ExternalClass2.hx
@@ -1,0 +1,25 @@
+package tests;
+
+import tests.TestCycle2.TestBase;
+
+class ExternalSubClass2 {
+  public function new() {}
+
+  public static function sub() {
+    return 'sub2';
+  }
+}
+
+class ExternalClass2 extends TestBase {
+  public function new() {
+    super();
+  }
+
+  @:keep public function test() {
+    return 'ok2';
+  }
+
+  public static function success() {
+    return 'success2';
+  }
+}

--- a/tests/TestImportModule.hx
+++ b/tests/TestImportModule.hx
@@ -2,6 +2,7 @@ package tests;
 
 import tink.unit.AssertionBuffer;
 import tests.ExternalClass;
+import tests.ExternalClass2;
 
 using tink.CoreApi;
 
@@ -29,14 +30,22 @@ class TestImportModule {
   }
 
   public function testImportMultiple(): Promise<AssertionBuffer> {
-    return genes.Genes.dynamicImport((ExternalClass, ExternalSubClass) -> {
-      var a = new ExternalClass();
-      asserts.assert(Std.is(a, ExternalClass));
-      asserts.assert(ExternalClass.success() == 'success');
-      var a = new ExternalSubClass();
-      asserts.assert(Std.is(a, ExternalSubClass));
-      asserts.assert(ExternalSubClass.sub() == 'sub');
-      return asserts.done();
-    }).ofJsPromise();
+    return genes.Genes.dynamicImport((ExternalClass, ExternalSubClass,
+        ExternalClass2, ExternalSubClass2) -> {
+        var a = new ExternalClass();
+        asserts.assert(Std.is(a, ExternalClass));
+        asserts.assert(ExternalClass.success() == 'success');
+        var a = new ExternalSubClass();
+        asserts.assert(Std.is(a, ExternalSubClass));
+        asserts.assert(ExternalSubClass.sub() == 'sub');
+        var a = new ExternalClass2();
+        asserts.assert(Std.is(a, ExternalClass2));
+        asserts.assert(ExternalClass2.success() == 'success2');
+        var a = new ExternalSubClass2();
+        asserts.assert(Std.is(a, ExternalSubClass2));
+        asserts.assert(ExternalSubClass2.sub() == 'sub2');
+        return asserts.done();
+      })
+      .ofJsPromise();
   }
 }

--- a/tests/TestImportModule.hx
+++ b/tests/TestImportModule.hx
@@ -5,6 +5,7 @@ import tests.ExternalClass;
 
 using tink.CoreApi;
 
+// TODO: we should probably also make sure the static import statements are not present in the generated js
 @:asserts
 class TestImportModule {
   public function new() {}
@@ -20,6 +21,18 @@ class TestImportModule {
 
   public function testImportSubModule(): Promise<AssertionBuffer> {
     return genes.Genes.dynamicImport(ExternalSubClass -> {
+      var a = new ExternalSubClass();
+      asserts.assert(Std.is(a, ExternalSubClass));
+      asserts.assert(ExternalSubClass.sub() == 'sub');
+      return asserts.done();
+    }).ofJsPromise();
+  }
+
+  public function testImportMultiple(): Promise<AssertionBuffer> {
+    return genes.Genes.dynamicImport((ExternalClass, ExternalSubClass) -> {
+      var a = new ExternalClass();
+      asserts.assert(Std.is(a, ExternalClass));
+      asserts.assert(ExternalClass.success() == 'success');
       var a = new ExternalSubClass();
       asserts.assert(Std.is(a, ExternalSubClass));
       asserts.assert(ExternalSubClass.sub() == 'sub');


### PR DESCRIPTION
```haxe
genes.Genes.dynamicImport(
  (ExternalClass, ExternalSubClass) -> {...}
);
```