### PR TITLE
ModuleEmitter: fix cast(myVar, MyInterface)

### DIFF
--- a/src/genes/es/ModuleEmitter.hx
+++ b/src/genes/es/ModuleEmitter.hx
@@ -211,7 +211,10 @@ class ModuleEmitter extends ExprEmitter {
     writeNewline();
     write('export const ');
     write(TypeUtil.className(cl));
-    write(' = {}');
+    write(' = function() {};');
+    writeNewline();
+    write(TypeUtil.className(cl));
+    write('.__isInterface__ = true;');
     writeNewline();
   }
 

--- a/tests/TestBoot.hx
+++ b/tests/TestBoot.hx
@@ -1,12 +1,24 @@
 package tests;
 
+interface MyInterface {}
+
+class MyInstance implements MyInterface {
+  public function new() {}
+}
+
 @:asserts
 class TestBoot {
   public function new() {}
 
-  public function testSafCast() {
+  public function testSafeCast() {
     var a: Dynamic = new TestBoot();
     asserts.assert((cast(a, TestBoot)) == a);
+    return asserts.done();
+  }
+
+  public function testInterfaceCast() {
+    var instance = new MyInstance();
+    asserts.assert((cast(instance, MyInterface)) == instance);
     return asserts.done();
   }
 }


### PR DESCRIPTION
Boot expects interfaces to be typeof === 'function' and have an `__isInterface__` field === true