### PR TITLE
Genes.dynamicImport() needs to include .js extension in emitted JS import() call

### DIFF
--- a/src/genes/Genes.hx
+++ b/src/genes/Genes.hx
@@ -43,8 +43,11 @@ class Genes {
               modules.push({
                 name: module,
                 importExpr: {
-                  final path = PathUtil.relative(current.replace('.', '/'),
+                  var path = PathUtil.relative(current.replace('.', '/'),
                     module.replace('.', '/'));
+                  #if !genes.no_extension
+                  path += ".js";
+                  #end
                   macro js.Syntax.code('import({0})', $v{path});
                 },
                 types: [


### PR DESCRIPTION
In web browsers, `import("./com/example/MyClass")` without the file's extension doesn't work. Tested in Safari, Firefox, and Chrome. None of them like it. They expect the file extension, like `import("./com/example/MyClass.js")`. Interestingly, it seems that bundlers like Webpack can handle the omitted file extension, so maybe the `Genes.dynamicImport()` feature was originally tested with an intermediate bundler step, and not directly in a web browser. Or maybe web browsers have gotten more strict over time.

Note: Like static imports, I made it skip the .js extension in dynamic `import()` calls when `genes.no-extension` is defined.