### PR TITLE
fix `do while` for haxe 4.3.1

### DIFF
--- a/.haxerc
+++ b/.haxerc
@@ -1,4 +1,4 @@
 {
-  "version": "779b005",
+  "version": "4.3.1",
   "resolveLibs": "scoped"
 }

--- a/src/genes/es/ExprEmitter.hx
+++ b/src/genes/es/ExprEmitter.hx
@@ -277,7 +277,10 @@ class ExprEmitter extends Emitter {
         this.inLoop = true;
         write('do ');
         emitExpr(e);
-        write('; while ');
+        switch e.expr {
+          case TBlock(el): write(' while ');
+          case _: write('; while ');
+        }
         emitValue(cond);
         this.inLoop = inLoop;
       case TObjectDecl(fields):

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -35,6 +35,7 @@ class Run {
       new TestGetterSetter(),
       new TestExpose(),
       new TestStatics(),
+      new TestDoWhile(),
       #if (haxe_ver >= 4.1)
       new TestException(),
       #end

--- a/tests/TestDoWhile.hx
+++ b/tests/TestDoWhile.hx
@@ -1,0 +1,22 @@
+package tests;
+
+import tink.unit.Assert.*;
+
+class TestDoWhile {
+  public function new() {}
+
+  public function testDoWhileExpr() {
+    var i = 0;
+    do i++ while(i < 10);
+    return assert(i == 10);
+  }
+  public function testDoWhileBody() {
+    var a = 0;
+    var b = 0;
+    do {
+      a++;
+      b++;
+    } while(a < 10);
+    return assert(b == 10);
+  }
+}


### PR DESCRIPTION
I didn't investigate where the error comes from, but there was a JS syntax error with haxe 4.3.1:
```
                }; while (a < 10);
                 ^
SyntaxError: Unexpected token ';'
```