### PR TITLE
Register: fix exception when resolve[Register.init] has already been cleared

### DIFF
--- a/src/genes/Register.hx
+++ b/src/genes/Register.hx
@@ -73,7 +73,7 @@ class Register {
         if (resolve && resolve[Register.init]) {
           defer = true
           res[Register.init] = () => {
-            resolve[Register.init]()
+            if (resolve[Register.init]) resolve[Register.init]()
             Object.setPrototypeOf(res.prototype, resolve.prototype)
             res[Register.init] = undefined
           } 


### PR DESCRIPTION
In some cases, it appears that calling `resolve[Register.init]()` fails because `resolve[Register.init]` is undefined. There is a check for `if (resolve && resolve[Register.init])`, but I guess that `__init__` gets must be getting set to undefined at some point after that check.

I can reproduce the issue with this sample.

https://github.com/joshtynjala/openfl-genes-sample

I have the latest OpenFL and Lime and Haxe 4.3.6 installed.