### PR TITLE
Fixes #82

### DIFF
--- a/src/genes/es/ExprEmitter.hx
+++ b/src/genes/es/ExprEmitter.hx
@@ -134,8 +134,8 @@ class ExprEmitter extends Emitter {
       case TField(x, f) if (fieldName(f) == "iterator" && isDynamicIterator(x)):
         switch (f) {
           case FStatic(c, cf):
-            write(c.get().name);
-            write(".iterator");
+            emitValue(x);
+            emitField("iterator");
           default:
             ctx.addFeature("use.$iterator");
             write(ctx.typeAccessor(registerType));

--- a/tests/Set.hx
+++ b/tests/Set.hx
@@ -1,0 +1,13 @@
+package tests;
+
+// benmerckx/genes#82
+@:forward
+abstract Set<T>(js.lib.Set<T>) {
+  public inline function new(?initial: Iterable<T>) {
+    this = new js.lib.Set<T>();
+  }
+
+  public function iterator(): js.lib.HaxeIterator<T> {
+    return new js.lib.HaxeIterator(this.values());
+  }
+}

--- a/tests/TestIterators.hx
+++ b/tests/TestIterators.hx
@@ -48,4 +48,16 @@ class TestIterators {
     final x = a.iterator;
     return assert(x().next() == 0);
   }
+
+  // benmerckx/genes#82
+  public function testIteratorWithImportAlias() {
+    final set = new Set<Int>();
+    set.add(1);
+    set.add(2);
+    var count = 0;
+    for (item in set) {
+      count++;
+    }
+    return assert(count == 2);
+  }
 }


### PR DESCRIPTION
Issue #82 describes an issue where the wrong name is emitted when generating an iterator call for an aliased import.  This PR fixes #82 by changing from using the static type name directly to using the field accessor, and changing write calls to emitValue and emitField.